### PR TITLE
Small enhancement in descriptions & method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # dart_kassakuitti_cli
 
-A simple Dart CLI app to handle a cash receipt coming from S-Kaupat (in Finland).
+A simple Dart CLI app to handle a cash receipt coming from S-Kaupat (a Finnish food online store).

--- a/bin/dart_kassakuitti_cli.dart
+++ b/bin/dart_kassakuitti_cli.dart
@@ -4,7 +4,7 @@ import 'product.dart';
 
 void main(List<String> arguments) {
   var lines = readFile('cashReceipt.txt');
-  var products = strings4Products(lines ?? []);
+  var products = strings2Products(lines ?? []);
 
   // Save products into CSV file
   saveProducts(products);
@@ -21,7 +21,7 @@ List<String>? readFile(String fileName) {
 }
 
 /// Goes through the list of lines and returns a list of products.
-List<Product> strings4Products(List<String> lines) {
+List<Product> strings2Products(List<String> lines) {
   var helper = Helper();
   List<Product> products = [];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_kassakuitti_cli
-description: A simple command-line application.
+description: A simple Dart CLI app to handle a cash receipt coming from S-Kaupat (a Finnish food online store).
 version: 1.0.0
 # homepage: https://www.example.com
 


### PR DESCRIPTION
- Update readme & pubspec descriptions
- Fix method name: 'strings4Products' -> 'strings2Products' 