### PR TITLE
Cash receipt: fix whitespace range between name & price

### DIFF
--- a/bin/specific/s_kaupat/strings_to_receipt_products.dart
+++ b/bin/specific/s_kaupat/strings_to_receipt_products.dart
@@ -102,8 +102,7 @@ List<ReceiptProduct> strings2ReceiptProducts(List<String> rows) {
 
     // A "normal" row:
     else {
-      var items = item.split(RegExp(r'\s{11,33}'));
-
+      var items = item.split(RegExp(r'\s{8,35}'));
       var name = items[0];
       var price = items[1];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_kassakuitti_cli
 description: A simple Dart CLI app to handle a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/areee/dart_kassakuitti_cli
 
 environment:


### PR DESCRIPTION
There was a bug that caused an exception with handling cash receipt rows. Originally, it didn't work when you've too long or too short product name in the cash receipt row. Now the whitespace range is a bit more flexible and the exception is gone.