### PR TITLE
Fix price saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.0
+
+- Update some dependencies.
+- When asking a user to give a proper number of a product (when there are multiple found products in the "run mode"), save correctly price to Hive products (use the total price when there's only one product in the receipt product; otherwise use the price per unit).
+
 ## 2.2.0
 
 - Add price & EAN code fields for a HiveProduct object. Add them when solving products in "run mode".

--- a/bin/ean_handler.dart
+++ b/bin/ean_handler.dart
@@ -156,7 +156,9 @@ Future<void> _handleFoundCases(
       await hiveProducts.add(HiveProduct(
         receiptName: receiptProduct.name,
         eanName: selectedEanProduct.name,
-        price: receiptProduct.pricePerUnit,
+        price: receiptProduct.quantity == 1
+            ? receiptProduct.totalPrice
+            : receiptProduct.pricePerUnit,
         eanCode: selectedEanProduct.eanCode,
       ));
       print(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_kassakuitti_cli
 description: A simple Dart CLI app to handle a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/areee/dart_kassakuitti_cli
 
 environment:


### PR DESCRIPTION
- When asking a user to give a proper number of a product (when there are multiple found products in the "run mode"), save correctly price to Hive products (use the total price when there's only one product in the receipt product; otherwise use the price per unit).