### PR TITLE
Update the 'kassakuitti' dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.11.0
+
+- Update a dependency (`kassakuitti`).
+  - It now seems to be more accurate with less previous problems with div parsing in S-kaupat HTML file.
+
 ## 2.10.0
 
 - Update a dependency.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -325,10 +325,10 @@ packages:
     dependency: "direct main"
     description:
       name: kassakuitti
-      sha256: "34c5670099211f5198bb5c228bf49a1b02d56747dac311f0f00dfc41f29cf769"
+      sha256: af2721b11587f641aad81348b55ca410293c5c293ea9673ebfb93dd65801d1eb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.6.0"
   lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_kassakuitti_cli
 description: A simple Dart CLI app to handle a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 2.10.0
+version: 2.11.0
 homepage: https://github.com/areee/dart_kassakuitti_cli
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   args: ^2.3.2
   hive: ^2.2.3
   intl: ^0.18.0
-  kassakuitti: ^0.5.2
+  kassakuitti: ^0.6.0
   mime: ^1.0.4
   path: ^1.8.3
   yaml: ^3.1.1


### PR DESCRIPTION
- Update a dependency (`kassakuitti`).
  - It now seems to be more accurate with less previous problems with div parsing in S-kaupat HTML file.